### PR TITLE
feat(onboarding): Create and connect activity level screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ This document provides a human-readable summary of key changes in the project. F
 ## [Unreleased]
 ### Added
 - **Onboarding Flow:**
+  - Created `ActivityLevelScreen.tsx` to allow users to select their activity level (e.g., Sedentary, Lightly Active).
+  - Connected the `GoalSettingScreen` to the `ActivityLevelScreen`.
   - Created `GoalSettingScreen.tsx` to allow users to select their primary fitness goal.
   - Connected the `DemographicsScreen` to the `GoalSettingScreen`.
 

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import WelcomeScreen from '../screens/Onboarding/WelcomeScreen';
 import DemographicsScreen from '../screens/Onboarding/DemographicsScreen';
 import GoalSettingScreen from '../screens/Onboarding/GoalSettingScreen';
+import ActivityLevelScreen from '../screens/Onboarding/ActivityLevelScreen';
 
 // It's a good practice to define your stack param list in a central place
 // to ensure type safety.
@@ -12,6 +13,7 @@ export type RootStackParamList = {
   Welcome: undefined; // No params expected for Welcome screen
   Demographics: undefined;
   GoalSetting: undefined;
+  ActivityLevel: undefined;
   // e.g., GoalSetting: { userId: string };
 };
 
@@ -24,6 +26,7 @@ const AppNavigator = () => {
         <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="Demographics" component={DemographicsScreen} />
         <Stack.Screen name="GoalSetting" component={GoalSettingScreen} />
+        <Stack.Screen name="ActivityLevel" component={ActivityLevelScreen} />
         {/* We will add more screens here for the rest of the onboarding flow */}
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/screens/Onboarding/ActivityLevelScreen.tsx
+++ b/src/screens/Onboarding/ActivityLevelScreen.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Button,
+  SafeAreaView,
+  Alert,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../navigation/AppNavigator';
+
+type ActivityLevel = 'sedentary' | 'lightly_active' | 'moderately_active' | 'very_active';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ActivityLevel'>;
+
+const ActivityLevelScreen = ({ navigation }: Props) => {
+  const [selectedLevel, setSelectedLevel] = useState<ActivityLevel | null>(null);
+
+  const handleNext = () => {
+    if (!selectedLevel) {
+      Alert.alert('Select a Level', 'Please choose your activity level to continue.');
+      return;
+    }
+    console.log('Selected Activity Level:', selectedLevel);
+    // This is the end of our current onboarding flow
+    Alert.alert('Onboarding Complete!', 'You are all set up.');
+  };
+
+  const levels: { key: ActivityLevel; label: string, description: string }[] = [
+    { key: 'sedentary', label: 'Sedentary', description: 'Little or no exercise' },
+    { key: 'lightly_active', label: 'Lightly Active', description: 'Exercise 1-3 days/week' },
+    { key: 'moderately_active', label: 'Moderately Active', description: 'Exercise 3-5 days/week' },
+    { key: 'very_active', label: 'Very Active', description: 'Hard exercise 6-7 days/week' },
+  ];
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>How Active Are You?</Text>
+      <Text style={styles.subtitle}>
+        This helps us set your baseline calorie and macro targets.
+      </Text>
+
+      <View style={styles.optionsContainer}>
+        {levels.map((level) => (
+          <TouchableOpacity
+            key={level.key}
+            style={[
+              styles.optionButton,
+              selectedLevel === level.key && styles.selectedOption,
+            ]}
+            onPress={() => setSelectedLevel(level.key)}
+          >
+            <Text style={[styles.optionLabel, selectedLevel === level.key && styles.selectedOptionText]}>
+              {level.label}
+            </Text>
+            <Text style={[styles.optionDescription, selectedLevel === level.key && styles.selectedOptionText]}>
+              {level.description}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Button title="Finish Setup" onPress={handleNext} disabled={!selectedLevel} />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginTop: 20,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: '#666',
+    marginBottom: 40,
+  },
+  optionsContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  optionButton: {
+    backgroundColor: '#f0f0f0',
+    padding: 20,
+    borderRadius: 10,
+    marginBottom: 15,
+    borderWidth: 2,
+    borderColor: 'transparent',
+    alignItems: 'center',
+  },
+  selectedOption: {
+    backgroundColor: '#007AFF',
+    borderColor: '#007AFF',
+  },
+  optionLabel: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#000',
+  },
+  optionDescription: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 4,
+  },
+  selectedOptionText: {
+    color: '#fff',
+  },
+});
+
+export default ActivityLevelScreen; 

--- a/src/screens/Onboarding/GoalSettingScreen.tsx
+++ b/src/screens/Onboarding/GoalSettingScreen.tsx
@@ -24,8 +24,8 @@ const GoalSettingScreen = ({ navigation }: Props) => {
       return;
     }
     console.log('Selected Goal:', selectedGoal);
-    // We will navigate to the next screen later
-    Alert.alert('Goal Saved!', `Your goal is to ${selectedGoal.replace('_', ' ')}.`);
+    // Navigate to the next screen
+    navigation.navigate('ActivityLevel');
   };
 
   const goals: { key: Goal; label: string }[] = [


### PR DESCRIPTION
### Summary

This pull request introduces the fourth and final screen for the initial version of the user onboarding flow: **Activity Level**. This screen prompts the user to select their general activity level, providing the last key piece of information needed to calculate baseline caloric and macronutrient needs.

This completes the initial data gathering phase of onboarding as outlined in `FR 1.2`.

### Changes

- Created the new `ActivityLevelScreen.tsx` component with a clear, multiple-choice UI.
- Updated `AppNavigator.tsx` to include the new screen.
- Modified `GoalSettingScreen.tsx` to navigate to the `ActivityLevelScreen`.
- Updated `CHANGELOG.md` to include this new feature under the `[Unreleased]` section.

### How to Test

1. Launch the app and proceed through the full onboarding flow.
2. After the Goal Setting screen, you should be on the "How Active Are You?" screen.
3. Select an activity level.
4. Tap "Finish Setup".
5. Confirm that the "Onboarding Complete!" alert appears.