### PR TITLE
feat(navigation): Create main tab navigator and connect to onboarding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ This document provides a human-readable summary of key changes in the project. F
 
 ## [Unreleased]
 ### Added
+- **Main App UI & Navigation:**
+  - Created the `MainTabNavigator` to serve as the primary navigation for the main application.
+  - Added placeholder screens for `DashboardScreen`, `WorkoutLogScreen`, `MealLogScreen`, and `ProfileScreen`.
+  - Connected the onboarding flow to the main app, navigating the user to the `DashboardScreen` upon completion.
 - **Onboarding Flow:**
   - Created `ActivityLevelScreen.tsx` to allow users to select their activity level (e.g., Sedentary, Lightly Active).
   - Connected the `GoalSettingScreen` to the `ActivityLevelScreen`.

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -1,33 +1,84 @@
- SynergyFit AI: Execution Plan
+# SynergyFit AI: Execution Plan
 
 This document outlines the development strategy for the SynergyFit AI application, focusing on an iterative, phased approach.
 
- Phase 1: Minimum Viable Product (MVP)
+---
+
+## Phase 1: Minimum Viable Product (MVP)
 
 The primary goal of Phase 1 is to rapidly develop and launch a core set of features to validate the product idea and gather user feedback. This phase corresponds to the "Freemium" tier defined in the PRD.
 
- Key Features for MVP:
-- FR 1.1-1.3: Onboarding & Goal Setting
-- FR 2: Manual Macronutrient & Calorie Tracking
-- FR 3: Manual Workout Log & Planner
-- FR 5: Basic Progress Tracking
-- FR 7: Core User Experience
+### Key Features for MVP:
+- **FR 1.1-1.3: Onboarding & Goal Setting:** User data collection.
+- **FR 2: Manual Macronutrient & Calorie Tracking:** Core food logging loop.
+- **FR 3: Manual Workout Log & Planner:** Core workout logging loop.
+- **FR 5: Basic Progress Tracking:** Simple dashboard and charts.
+- **FR 7: Core User Experience:** An intuitive and clean UI.
 
- Technical Stack for MVP:
-- Cross-Platform Framework: React Native
-- Backend-as-a-Service (BaaS): Supabase
-- Database: PostgreSQL (managed by Supabase)
+### Technical Stack for MVP:
+- **Cross-Platform Framework:** React Native
+- **Backend-as-a-Service (BaaS):** Supabase (for Auth, Database, Storage)
+- **Database:** PostgreSQL (managed by Supabase)
 
 ---
 
- Phase 2: Premium AI & Integration Features
+## Phase 2: Premium AI & Integration Features
 
 Once the MVP is stable, we will develop the core premium features.
 
- Key Features for Phase 2:
-- FR 4.1-4.5: AI-Powered Planning & Coaching
-- FR 6: Integrations (Apple HealthKit, Google Fit)
-- Monetization: Implement premium subscription model.
+### Key Features for Phase 2:
+- **FR 4.1-4.5: AI-Powered Planning & Coaching**
+- **FR 6: Integrations (Apple HealthKit, Google Fit)**
+- **Monetization:** Implement premium subscription model.
 
- Technical Additions for Phase 2:
-- AI Microservice: A separate Python service for handling complex AI computations.
+### Technical Additions for Phase 2:
+- **AI Microservice:** A separate Python service for handling complex AI computations.
+
+---
+
+## Front-End Architecture Blueprint
+
+This section outlines the planned screen and navigation structure for the application.
+
+### 1. Root Navigator (Stack)
+Manages the switch between Authentication, Onboarding, and the Main App.
+
+### 2. Authentication Flow (Stack)
+- `LoginScreen`: For existing users to sign in.
+- `SignUpScreen`: For new users to create an account.
+- `ForgotPasswordScreen`: For password recovery.
+
+### 3. Onboarding Flow (Stack)
+*A one-time setup process for new, authenticated users.*
+- `WelcomeScreen`
+- `DemographicsScreen`
+- `GoalSettingScreen`
+- `ActivityLevelScreen`
+
+### 4. Main App (Bottom Tab Navigator)
+*The core interface for authenticated users.*
+- **Dashboard Tab:**
+  - `DashboardScreen`: High-level summary of daily progress.
+- **Meals Tab:**
+  - `MealLogScreen`: The primary hub for food logging.
+- **Workouts Tab:**
+  - `WorkoutLogScreen`: The primary hub for workout logging.
+- **Profile Tab:**
+  - `ProfileScreen`: Hub for user settings, stats, and app configuration.
+
+### 5. Detail Screens (Pushed onto the Stack)
+*Screens that are navigated to from within the main tabs.*
+- **From Meals:**
+  - `FoodSearchScreen`
+  - `BarcodeScannerScreen`
+  - `RecipeCreatorScreen`
+- **From Workouts:**
+  - `WorkoutPlannerScreen`
+  - `ExerciseLibraryScreen`
+  - `ExerciseDetailScreen`
+  - `ActiveWorkoutScreen`
+- **From Profile:**
+  - `EditProfileScreen`
+  - `NotificationSettingsScreen`
+  - `IntegrationsScreen`
+  - `SubscriptionScreen`

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "SynergyFit",
       "version": "0.0.1",
       "dependencies": {
+        "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "react": "19.0.0",
@@ -3111,6 +3112,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.3.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.3.14.tgz",
+      "integrity": "sha512-s2qinJggS2HYZdCOey9A+fN+bNpWeEKwiL/FjAVOTcv+uofxPWN6CtEZUZGPEjfRjis/srURBmCmpNZSI6sQ9Q==",
+      "dependencies": {
+        "@react-navigation/elements": "^2.4.3",
+        "color": "^4.2.3"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.10",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
       }
     },
     "node_modules/@react-navigation/core": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",
     "react": "19.0.0",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -6,6 +6,7 @@ import WelcomeScreen from '../screens/Onboarding/WelcomeScreen';
 import DemographicsScreen from '../screens/Onboarding/DemographicsScreen';
 import GoalSettingScreen from '../screens/Onboarding/GoalSettingScreen';
 import ActivityLevelScreen from '../screens/Onboarding/ActivityLevelScreen';
+import MainTabNavigator from './MainTabNavigator';
 
 // It's a good practice to define your stack param list in a central place
 // to ensure type safety.
@@ -14,6 +15,7 @@ export type RootStackParamList = {
   Demographics: undefined;
   GoalSetting: undefined;
   ActivityLevel: undefined;
+  MainApp: undefined;
   // e.g., GoalSetting: { userId: string };
 };
 
@@ -27,6 +29,7 @@ const AppNavigator = () => {
         <Stack.Screen name="Demographics" component={DemographicsScreen} />
         <Stack.Screen name="GoalSetting" component={GoalSettingScreen} />
         <Stack.Screen name="ActivityLevel" component={ActivityLevelScreen} />
+        <Stack.Screen name="MainApp" component={MainTabNavigator} />
         {/* We will add more screens here for the rest of the onboarding flow */}
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/navigation/MainTabNavigator.tsx
+++ b/src/navigation/MainTabNavigator.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+// Import the placeholder screens
+import DashboardScreen from '../screens/main/DashboardScreen';
+import WorkoutLogScreen from '../screens/main/WorkoutLogScreen';
+import MealLogScreen from '../screens/main/MealLogScreen';
+import ProfileScreen from '../screens/main/ProfileScreen';
+
+export type MainTabParamList = {
+  Dashboard: undefined;
+  WorkoutLog: undefined;
+  MealLog: undefined;
+  Profile: undefined;
+};
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+const MainTabNavigator = () => {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false, // We can hide the header for a cleaner look
+        tabBarActiveTintColor: '#007AFF',
+        tabBarInactiveTintColor: 'gray',
+      }}
+    >
+      <Tab.Screen name="Dashboard" component={DashboardScreen} />
+      <Tab.Screen name="WorkoutLog" component={WorkoutLogScreen} options={{ title: 'Workouts' }} />
+      <Tab.Screen name="MealLog" component={MealLogScreen} options={{ title: 'Meals' }} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+};
+
+export default MainTabNavigator;

--- a/src/screens/Onboarding/ActivityLevelScreen.tsx
+++ b/src/screens/Onboarding/ActivityLevelScreen.tsx
@@ -25,7 +25,10 @@ const ActivityLevelScreen = ({ navigation }: Props) => {
     }
     console.log('Selected Activity Level:', selectedLevel);
     // This is the end of our current onboarding flow
-    Alert.alert('Onboarding Complete!', 'You are all set up.');
+    // We navigate to the main app, which is a tab navigator.
+    // The `replace` action removes the onboarding stack from history,
+    // so the user can't press "back" to go back into the setup flow.
+    navigation.replace('MainApp');
   };
 
   const levels: { key: ActivityLevel; label: string, description: string }[] = [

--- a/src/screens/main/DashboardScreen.tsx
+++ b/src/screens/main/DashboardScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+
+const DashboardScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Dashboard</Text>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default DashboardScreen; 

--- a/src/screens/main/MealLogScreen.tsx
+++ b/src/screens/main/MealLogScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+
+const MealLogScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Meal Log</Text>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default MealLogScreen; 

--- a/src/screens/main/ProfileScreen.tsx
+++ b/src/screens/main/ProfileScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+
+const ProfileScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Profile</Text>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default ProfileScreen; 

--- a/src/screens/main/WorkoutLogScreen.tsx
+++ b/src/screens/main/WorkoutLogScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+
+const WorkoutLogScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Workout Log</Text>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});
+
+export default WorkoutLogScreen; 


### PR DESCRIPTION
### Summary

This pull request establishes the primary UI structure for the main application by creating a bottom tab navigator. It also completes the initial user journey by connecting the end of the onboarding flow to this new main interface.

### Changes

- **Navigation:**
  - Added the `@react-navigation/bottom-tabs` library.
  - Created `MainTabNavigator.tsx` to define the core tab-based navigation (Dashboard, Workouts, Meals, Profile).
  - Updated the root `AppNavigator` to include a route to the `MainTabNavigator`.
  - Modified the final onboarding screen (`ActivityLevelScreen`) to transition the user into the main app using `navigation.replace`.

- **UI (Placeholders):**
  - Created placeholder screens for `DashboardScreen`, `WorkoutLogScreen`, `MealLogScreen`, and `ProfileScreen`.

- **Documentation:**
  - Updated `EXECUTION_PLAN.md` with the front-end architecture blueprint.
  - Updated `CHANGELOG.md` to reflect these changes.

### How to Test

1. Launch the app and proceed through the entire onboarding flow.
2. On the "Activity Level" screen, select an option and tap "Finish Setup".
3. Verify that you are navigated to the main application and see the "Dashboard" screen with a tab bar at the bottom containing "Dashboard", "Workouts", "Meals", and "Profile".
4. Tap on each tab to ensure the corresponding placeholder screen is displayed.